### PR TITLE
Update OpenCoverParser.cs

### DIFF
--- a/ReportGenerator/Parser/OpenCoverParser.cs
+++ b/ReportGenerator/Parser/OpenCoverParser.cs
@@ -343,27 +343,24 @@ namespace Palmmedia.ReportGenerator.Parser
 
                 foreach (var seqpnt in seqpntsOfFile)
                 {
-                    for (int lineNumber = seqpnt.LineNumberStart; lineNumber <= seqpnt.LineNumberEnd; lineNumber++)
-                    {
-                        int visits = coverage[lineNumber] == -1 ? seqpnt.Visits : coverage[lineNumber] + seqpnt.Visits;
-                        coverage[lineNumber] = visits;
+                    int visits = coverage[lineNumber] == -1 ? seqpnt.Visits : coverage[lineNumber] + seqpnt.Visits;
+                    coverage[lineNumber] = visits;
 
-                        if (visits > -1)
+                    if (visits > -1)
+                    {
+                        foreach (var trackedMethodCoverage in trackedMethodsCoverage)
                         {
-                            foreach (var trackedMethodCoverage in trackedMethodsCoverage)
+                            if (trackedMethodCoverage.Value[lineNumber] == -1)
                             {
-                                if (trackedMethodCoverage.Value[lineNumber] == -1)
-                                {
-                                    trackedMethodCoverage.Value[lineNumber] = 0;
-                                }
+                                trackedMethodCoverage.Value[lineNumber] = 0;
                             }
                         }
+                    }
 
-                        foreach (var trackedMethod in seqpnt.TrackedMethodRefs)
-                        {
-                            var trackedMethodCoverage = trackedMethodsCoverage[trackedMethod.TrackedMethodId];
-                            trackedMethodCoverage[lineNumber] = trackedMethodCoverage[lineNumber] == -1 ? trackedMethod.Visits : trackedMethodCoverage[lineNumber] + trackedMethod.Visits;
-                        }
+                    foreach (var trackedMethod in seqpnt.TrackedMethodRefs)
+                    {
+                        var trackedMethodCoverage = trackedMethodsCoverage[trackedMethod.TrackedMethodId];
+                        trackedMethodCoverage[lineNumber] = trackedMethodCoverage[lineNumber] == -1 ? trackedMethod.Visits : trackedMethodCoverage[lineNumber] + trackedMethod.Visits;
                     }
                 }
             }


### PR DESCRIPTION
Code to update data from sl to el in SequencePoint is causing the Report to count anonymous delegates and lambdas as fully covered even if they have not been exectured.  It also overcounts single code lines that span multiple lines, effecting the coverage percentage.  This code will break the coloring of subsequent lines in the actual case of multiple lines for formatting, but fixes the count.
